### PR TITLE
Revert "Updated to maven 3.3.9"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM garethjevans/jenkinsslave:v1.2.3-alpine
 
-ENV MAVEN_VERSION 3.3.9
+ENV MAVEN_VERSION 3.2.2
 ENV MAVEN_HOME /opt/maven
 ENV SBT_VERSION 0.13.9
 ENV GRADLE_VERSION 2.11


### PR DESCRIPTION
This reverts commit 9a31e7f057d4b092b1b362f582d1a2333ddfa9c4.

Apparently, Maven versions 3.2.3 thru 3.3.9 have bugs - see
https://issues.apache.org/jira/browse/MNG-5868 and
https://issues.apache.org/jira/browse/MNG-5939. Those versions
generate and deploy sources and javadoc jars twice when doing a
release.